### PR TITLE
Directly call dart executable instead of sass wrapper on windows and …

### DIFF
--- a/AspNetCore.SassCompiler/SassCompilerAttribute.cs
+++ b/AspNetCore.SassCompiler/SassCompilerAttribute.cs
@@ -4,11 +4,13 @@ namespace AspNetCore.SassCompiler
 {
     public class SassCompilerAttribute : Attribute
     {
-        public SassCompilerAttribute(string sassBinary)
+        public SassCompilerAttribute(string sassBinary, string sassSnapshot)
         {
             SassBinary = sassBinary;
+            SassSnapshot = sassSnapshot;
         }
 
         internal string SassBinary { get; }
+        internal string SassSnapshot { get; }
     }
 }

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.props
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.props
@@ -1,9 +1,12 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <SassCompilerBuildCommand Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(MSBuildThisFileDirectory)..\runtimes\win-x64\sass.bat</SassCompilerBuildCommand>
+    <SassCompilerBuildCommand Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(MSBuildThisFileDirectory)..\runtimes\win-x64\src\dart.exe</SassCompilerBuildCommand>
+    <SassCompilerBuildSnapshot Condition="$([MSBuild]::IsOSPlatform('Windows'))">&quot;$(MSBuildThisFileDirectory)..\runtimes\win-x64\src\sass.snapshot&quot;</SassCompilerBuildSnapshot>
     <SassCompilerBuildCommand Condition="$([MSBuild]::IsOSPlatform('Linux'))">$(MSBuildThisFileDirectory)..\runtimes\linux-x64\sass</SassCompilerBuildCommand>
-    <SassCompilerBuildCommand Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(MSBuildThisFileDirectory)..\runtimes\osx-x64\sass</SassCompilerBuildCommand>
+    <SassCompilerBuildSnapshot Condition="$([MSBuild]::IsOSPlatform('Linux'))"> </SassCompilerBuildSnapshot>
+    <SassCompilerBuildCommand Condition="$([MSBuild]::IsOSPlatform('OSX'))">$(MSBuildThisFileDirectory)..\runtimes\osx-x64\src\dart</SassCompilerBuildCommand>
+    <SassCompilerBuildSnapshot Condition="$([MSBuild]::IsOSPlatform('OSX'))">&quot;$(MSBuildThisFileDirectory)..\runtimes\osx-x64\src\sass.snapshot&quot;</SassCompilerBuildSnapshot>
 
     <SassCompilerDotNetJsonDll>$(MSBuildThisFileDirectory)..\runtimes\dotnet-json.dll</SassCompilerDotNetJsonDll>
 
@@ -17,6 +20,7 @@
   <ItemGroup>
     <AssemblyAttribute Include="AspNetCore.SassCompiler.SassCompilerAttribute">
       <_Parameter1>$(SassCompilerBuildCommand)</_Parameter1>
+      <_Parameter2>$(SassCompilerBuildSnapshot)</_Parameter2>
     </AssemblyAttribute>
   </ItemGroup>
 

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -31,7 +31,7 @@
       <Output TaskParameter="ExitCode" PropertyName="SassCompilerArgumentsExitCode" />
       <Output TaskParameter="ConsoleOutput" PropertyName="SassCompilerArguments" Condition="'$(SassCompilerArgumentsExitCode)' == '0'" />
     </Exec>
-    <Exec Command="&quot;$(SassCompilerBuildCommand)&quot; $(SassCompilerArguments) &quot;$(ProjectDir)$(SassCompilerSourceFolder)&quot;:&quot;$(ProjectDir)$(SassCompilerTargetFolder)&quot;" />
+    <Exec Command="&quot;$(SassCompilerBuildCommand)&quot; $(SassCompilerBuildSnapshot) $(SassCompilerArguments) &quot;$(ProjectDir)$(SassCompilerSourceFolder)&quot;:&quot;$(ProjectDir)$(SassCompilerTargetFolder)&quot;" />
   </Target>
 
 </Project>


### PR DESCRIPTION
…osx and kill process if it hasnt exited on dispose.

Fixes #31 