### PR TITLE
Run Compile Sass target before BundleMinify task from BuildBundleMinifier

### DIFF
--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -3,7 +3,7 @@
   <UsingTask TaskName="AspNetCore.SassCompiler.CompileSass"
              AssemblyFile="$(SassCompilerAssembly)" />
 
-  <Target Name="Compile Sass" BeforeTargets="Build;ResolveScopedCssInputs">
+  <Target Name="Compile Sass" BeforeTargets="Build;ResolveScopedCssInputs;BundleMinify">
     <CompileSass AppsettingsFile="$(SassCompilerAppsettingsJson)"
                  Command="$(SassCompilerBuildCommand)"
                  Snapshot="$(SassCompilerBuildSnapshot)">


### PR DESCRIPTION

Fixes #52