### PR TITLE
Read StandardOutput and StandardError before WaitForExit

### DIFF
--- a/AspNetCore.SassCompiler.Tasks/CompileSass.cs
+++ b/AspNetCore.SassCompiler.Tasks/CompileSass.cs
@@ -143,16 +143,18 @@ namespace AspNetCore.SassCompiler
                 };
 
                 compiler.Start();
+                
+                var error = compiler.StandardError.ReadToEnd();
+                var output = compiler.StandardOutput.ReadToEnd();
+                
                 compiler.WaitForExit();
 
                 if (compiler.ExitCode != 0)
                 {
-                    var error = compiler.StandardError.ReadToEnd();
                     Log.LogError($"Error running sass compiler: {error}.");
                     yield break;
                 }
 
-                var output = compiler.StandardOutput.ReadToEnd();
                 var matches = _compiledFilesRe.Matches(output);
 
                 foreach (Match match in matches)
@@ -196,16 +198,18 @@ namespace AspNetCore.SassCompiler
             };
 
             compiler.Start();
+
+            var output = compiler.StandardOutput.ReadToEnd();
+            var error = compiler.StandardError.ReadToEnd();
+            
             compiler.WaitForExit();
 
             if (compiler.ExitCode != 0)
             {
-                var error = compiler.StandardError.ReadToEnd();
                 Log.LogError($"Error running sass compiler: {error}.");
                 yield break;
             }
 
-            var output = compiler.StandardOutput.ReadToEnd();
             var matches = _compiledFilesRe.Matches(output);
 
             foreach (Match match in matches)


### PR DESCRIPTION
This avoids a deadlock. From the Microsoft docs at https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standardoutput?redirectedfrom=MSDN&view=net-6.0#remarks:

>A deadlock condition can result if the parent process calls p.WaitForExit before p.StandardOutput.ReadToEnd and the child process writes enough text to fill the redirected stream. The parent process would wait indefinitely for the child process to exit. The child process would wait indefinitely for the parent to read from the full StandardOutput stream.

This fixes #71.