### PR TITLE
Update version to 1.51.0.1

### DIFF
--- a/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
+++ b/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackageId>AspNetCore.SassCompiler</PackageId>
-    <Version>1.51.0</Version>
+    <Version>1.51.0.1</Version>
     <Authors>koenvzeijl,sleeuwen,Michaelvs97</Authors>
     <Description>Sass Compiler Library for .NET Core 3.1/5.x/6.x. without node</Description>
     <PackageDescription>Sass Compiler Library for .NET Core 3.1/5.x/6.x. without node, using dart-sass as a compiler</PackageDescription>


### PR DESCRIPTION
In order for us to be able to use this package we need it as NuGet package with the changes from #72. The automatic publishing via GitHub workflow failed on Friday, probably because the version number has not been bumped, see https://github.com/koenvzeijl/AspNetCore.SassCompiler/runs/6207096814?check_suite_focus=true#step:5:10.