### PR TITLE
Avoid deadlock when reading both StandardOutput and StandardError

### DIFF
--- a/AspNetCore.SassCompiler.Tasks/CompileSass.cs
+++ b/AspNetCore.SassCompiler.Tasks/CompileSass.cs
@@ -207,10 +207,17 @@ namespace AspNetCore.SassCompiler
                 RedirectStandardError = true,
             };
 
+            string error = null;
+            compiler.ErrorDataReceived += (sender, e) =>
+            {
+                error += e.Data;
+            };
+            
             compiler.Start();
 
+            compiler.BeginErrorReadLine();
+            
             var output = compiler.StandardOutput.ReadToEnd();
-            var error = compiler.StandardError.ReadToEnd();
 
             compiler.WaitForExit();
 

--- a/AspNetCore.SassCompiler.Tasks/CompileSass.cs
+++ b/AspNetCore.SassCompiler.Tasks/CompileSass.cs
@@ -210,7 +210,7 @@ namespace AspNetCore.SassCompiler
             string error = null;
             compiler.ErrorDataReceived += (sender, e) =>
             {
-                error += e.Data;
+                error += e.Data + "\r\n";
             };
             
             compiler.Start();

--- a/AspNetCore.SassCompiler.Tasks/CompileSass.cs
+++ b/AspNetCore.SassCompiler.Tasks/CompileSass.cs
@@ -210,7 +210,7 @@ namespace AspNetCore.SassCompiler
             string error = null;
             compiler.ErrorDataReceived += (sender, e) =>
             {
-                error += e.Data + "\r\n";
+                error += e.Data + Environment.NewLine;
             };
             
             compiler.Start();

--- a/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
+++ b/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackageId>AspNetCore.SassCompiler</PackageId>
-    <Version>1.51.0.1</Version>
+    <Version>1.51.0.2</Version>
     <Authors>koenvzeijl,sleeuwen,Michaelvs97</Authors>
     <Description>Sass Compiler Library for .NET Core 3.1/5.x/6.x. without node</Description>
     <PackageDescription>Sass Compiler Library for .NET Core 3.1/5.x/6.x. without node, using dart-sass as a compiler</PackageDescription>


### PR DESCRIPTION
Unfortunately the fix in #72 does not completely solve all deadlock problems. If all SCSS files are valid and contain no problems, the compilation succeeds – even if there are lots of SCSS files. But if there are SCSS files containing problems, the compilation runs into a deadlock again.

From the Microsoft docs at https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.standarderror?view=net-6.0#remarks:
>A deadlock condition results if the parent process calls p.StandardOutput.ReadToEnd followed by p.StandardError.ReadToEnd and the child process writes enough text to fill its error stream. The parent process would wait indefinitely for the child process to close its StandardOutput stream. The child process would wait indefinitely for the parent to read from the full StandardError stream.

This PR should fix the problem by applying the workaround described in the Microsoft docs referenced above.
