### PR TITLE
Show warning message if SCSS compilation succeeds but error message exists

### DIFF
--- a/AspNetCore.SassCompiler.Tasks/CompileSass.cs
+++ b/AspNetCore.SassCompiler.Tasks/CompileSass.cs
@@ -142,6 +142,11 @@ namespace AspNetCore.SassCompiler
                     yield break;
                 }
 
+                if (!string.IsNullOrWhiteSpace(error))
+                {
+                    Log.LogWarning(error);
+                }
+
                 var matches = _compiledFilesRe.Matches(output);
 
                 foreach (Match match in matches)
@@ -183,6 +188,11 @@ namespace AspNetCore.SassCompiler
                 yield break;
             }
 
+            if (!string.IsNullOrWhiteSpace(error))
+            {
+                Log.LogWarning(error);
+            }
+            
             var matches = _compiledFilesRe.Matches(output);
 
             foreach (Match match in matches)


### PR DESCRIPTION
This might happen if the SCSS uses deprecated features, for example:

```scss
$value: 11/7;
```

The Dart Sass compilation writes the following warning message to the error output in this case:

>DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.
>Recommendation: math.div(11, 7)
>More info and automated migrator: https://sass-lang.com/d/slash-div

By logging these messages as warning one gets the following output in their IDE of choice, for instance in Rider:

![image](https://user-images.githubusercontent.com/42088160/166634738-ba4fd4bf-1ffb-47c5-b463-814e85c5c3cf.png)
