### PR TITLE
Fix SCSS compilation for subsequent builds

### DIFF
--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
 
   <ItemGroup>
     <UpToDateCheckInput Include="**/*.scss" />
@@ -18,6 +18,7 @@
     </CompileSass>
 
     <ItemGroup>
+      <None Remove="@(CompiledCssFiles)" />
       <Content Include="@(CompiledCssFiles)" />
     </ItemGroup>
   </Target>

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -1,5 +1,9 @@
-﻿<Project>
+<Project>
 
+  <ItemGroup>
+    <UpToDateCheckInput Include="**/*.scss" />
+  </ItemGroup>
+  
   <UsingTask TaskName="AspNetCore.SassCompiler.CompileSass"
              AssemblyFile="$(SassCompilerTasksAssembly)" />
 


### PR DESCRIPTION
While working in my IDE I noticed that changes to .scss files do not get picked up by MSBuild.

How to reproduce:

1. Build the sample project [AspNetCore.SassCompiler.RazorClassLibrary](https://github.com/koenvzeijl/AspNetCore.SassCompiler/tree/master/Samples/AspNetCore.SassCompiler.RazorClassLibrary).
2. Change some styles in [Component1.razor.scss](https://github.com/koenvzeijl/AspNetCore.SassCompiler/blob/master/Samples/AspNetCore.SassCompiler.RazorClassLibrary/Component1.razor.scss).
3. Build again. Notice the build is immediately finished as MSBuild does not think any inputs have changed.
![image](https://user-images.githubusercontent.com/42088160/166660641-fcc72dfa-b070-4a8d-b4e5-e9ab28a7aa55.png)

By adding the following `ItemGroup` to [AspNetCore.SassCompiler.targets](https://github.com/koenvzeijl/AspNetCore.SassCompiler/blob/master/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets) the changes to .scss files are recognized properly:
```xml
  <ItemGroup>
    <UpToDateCheckInput Include="**/*.scss" />
  </ItemGroup>
``` 

---------

Repeating the workflow described above leads to an error now, however:

![image](https://user-images.githubusercontent.com/42088160/166661026-eac252d4-b3e3-4552-ab83-1df8c3e5b8a9.png)

To fix this the generated files have to be removed from the build before adding them in order to avoid these kinds of duplicates. This can be done by adding the following to [AspNetCore.SassCompiler.targets](https://github.com/koenvzeijl/AspNetCore.SassCompiler/blob/master/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets):
```xml
<None Remove="@(CompiledCssFiles)" />
```
