### PR TITLE
Set regular expression to use multiline mode

### DIFF
--- a/AspNetCore.SassCompiler.Tasks/CompileSass.cs
+++ b/AspNetCore.SassCompiler.Tasks/CompileSass.cs
@@ -12,7 +12,7 @@ namespace AspNetCore.SassCompiler
 {
     public sealed class CompileSass : Task
     {
-        private static readonly Regex _compiledFilesRe = new Regex(@"^Compiled (.+?) to (.+).$");
+        private static readonly Regex _compiledFilesRe = new Regex(@"^Compiled (.+?) to (.+).$", RegexOptions.Multiline);
 
         public string AppsettingsFile { get; set; }
 


### PR DESCRIPTION
The `Compile Sass` task does not produce any `OutputItems` when two or more SCSS files are compiled. This is problematic as the following `ResolveScopedCssInputs` task only works if these items exist.

------

To reproduce I used the sample project [AspNetCore.SassCompiler.RazorClassLibrary](https://github.com/koenvzeijl/AspNetCore.SassCompiler/tree/master/Samples/AspNetCore.SassCompiler.RazorClassLibrary):

Excerpt from the build's `.binlog` if **one** SCSS file gets compiled:
![image](https://user-images.githubusercontent.com/42088160/167149222-f62b3e44-6ac8-4303-9e94-d04f266f7df6.png)

Excerpt from the build's `.binlog` if **two** SCSS file gets compiled (I duplicated `Component1` as `Component2`):

![image](https://user-images.githubusercontent.com/42088160/167146442-89ac5dfc-9c82-42ff-88f4-2dd6e88f499e.png)

Notice how no `OutputItems` are produced by the `Compile Sass` task.

This is due to the used regular expression not matching the input. If `RegexOptions.Multiline` is used, the console output of the `dart` command is properly matched and the `OutputItems` are produced as expected:

![image](https://user-images.githubusercontent.com/42088160/167150596-217e8482-13ea-4328-96dd-ec9b4e723a55.png)

