### PR TITLE
Mark package as development dependency

### DIFF
--- a/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
+++ b/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
@@ -14,6 +14,7 @@
     <LangVersion>8.0</LangVersion>
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <DevelopmentDependency>true</DevelopmentDependency>
   </PropertyGroup>
 
   <!-- Enable trimming so the dll can be trimmed away from the output if used (e.g. in blazor) -->


### PR DESCRIPTION
This change marks the NuGet package as development dependency. This causes a different `PackageReference` entry to be generated in the project file when it is installed:

`<DevelopmentDependency>false</DevelopmentDependency>`:
```xml
<PackageReference Include="AspNetCore.SassCompiler" Version="1.51.0" />
```

`<DevelopmentDependency>true</DevelopmentDependency>`:
```xml
<PackageReference Include="AspNetCore.SassCompiler" Version="1.51.0">
  <PrivateAssets>all</PrivateAssets>
  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
</PackageReference>
```

This in turn makes sure that the `AspNetCore.SassCompiler.dll` does not end up in the published build result of projects simply referencing it for development purposes.

See also: https://docs.microsoft.com/en-us/nuget/reference/nuspec#developmentdependency