### PR TITLE
Skip ChildProcessTracker initialization on non-Windows platforms

### DIFF
--- a/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
+++ b/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackageId>AspNetCore.SassCompiler</PackageId>
-    <Version>1.52.1</Version>
+    <Version>1.52.1.1</Version>
     <Authors>koenvzeijl,sleeuwen,Michaelvs97</Authors>
     <Description>Sass Compiler Library for .NET Core 3.1/5.x/6.x. without node</Description>
     <PackageDescription>Sass Compiler Library for .NET Core 3.1/5.x/6.x. without node, using dart-sass as a compiler</PackageDescription>

--- a/AspNetCore.SassCompiler/ChildProcessTracker.cs
+++ b/AspNetCore.SassCompiler/ChildProcessTracker.cs
@@ -30,6 +30,9 @@ namespace AspNetCore.SassCompiler
 
         static ChildProcessTracker()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                return;
+
             // This feature requires Windows 8 or later. To support Windows 7 requires
             //  registry settings to be added if you are using Visual Studio plus an
             //  app.manifest change.


### PR DESCRIPTION
Fixes #90 