### PR TITLE
Fix issue with duplicate scoped css folders during watch

### DIFF
--- a/AspNetCore.SassCompiler.Tasks/CompileSass.cs
+++ b/AspNetCore.SassCompiler.Tasks/CompileSass.cs
@@ -66,6 +66,9 @@ namespace AspNetCore.SassCompiler
                 }
             }
 
+            if (options.ScopedCssFolders == null)
+                options.ScopedCssFolders = SassCompilerOptions.DefaultScopedCssFolders;
+
             if (options.Arguments.Contains("--watch"))
             {
                 Log.LogWarning("Cannot use --watch as sass argument when running in MSBuild, use the .AddSassCompiler() method on the IServiceCollection instead.");
@@ -209,7 +212,7 @@ namespace AspNetCore.SassCompiler
             if (!options.GenerateScopedCss)
                 yield break;
 
-            var directories = new List<string>();
+            var directories = new HashSet<string>();
             foreach (var dir in options.ScopedCssFolders)
             {
                 if (Directory.Exists(dir))

--- a/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
+++ b/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackageId>AspNetCore.SassCompiler</PackageId>
-    <Version>1.52.1.1</Version>
+    <Version>1.52.1.2</Version>
     <Authors>koenvzeijl,sleeuwen,Michaelvs97</Authors>
     <Description>Sass Compiler Library for .NET Core 3.1/5.x/6.x. without node</Description>
     <PackageDescription>Sass Compiler Library for .NET Core 3.1/5.x/6.x. without node, using dart-sass as a compiler</PackageDescription>

--- a/AspNetCore.SassCompiler/SassCompilerHostedService.cs
+++ b/AspNetCore.SassCompiler/SassCompilerHostedService.cs
@@ -50,6 +50,9 @@ namespace AspNetCore.SassCompiler
                 configuration.GetSection("SassCompiler").Bind(options);
             }
 
+            if (options.ScopedCssFolders == null)
+                options.ScopedCssFolders = SassCompilerOptions.DefaultScopedCssFolders;
+
             if (options.Arguments.Contains("--watch"))
                 options.Arguments = options.Arguments.Replace("--watch", "");
 
@@ -156,7 +159,7 @@ namespace AspNetCore.SassCompiler
             if (command.Filename == null)
                 return null;
 
-            var directories = new List<string>();
+            var directories = new HashSet<string>();
             directories.Add($"\"{Path.Join(rootFolder, _options.SourceFolder)}\":\"{Path.Join(rootFolder, _options.TargetFolder)}\"");
             if (_options.GenerateScopedCss)
             {

--- a/AspNetCore.SassCompiler/SassCompilerOptions.cs
+++ b/AspNetCore.SassCompiler/SassCompilerOptions.cs
@@ -3,6 +3,7 @@ namespace AspNetCore.SassCompiler
     internal class SassCompilerOptions
     {
         public const string DefaultSourceFolder = "Styles";
+        public static readonly string[] DefaultScopedCssFolders = new[] { "Views", "Pages", "Shared", "Components" };
 
         private string _sourceFolder = DefaultSourceFolder;
         public string SourceFolder
@@ -22,6 +23,6 @@ namespace AspNetCore.SassCompiler
 
         public bool GenerateScopedCss { get; set; } = true;
 
-        public string[] ScopedCssFolders { get; set; } = new[] { "Views", "Pages", "Shared", "Components" };
+        public string[] ScopedCssFolders { get; set; } = null;
     }
 }


### PR DESCRIPTION
Fixes an issue where the sass process fails to start when the "ScopedCssFolders" appsettings is used with some of the default values.

It will now initialize the options without ScopedCssFolders, and when options are validated it will set it to the default folders if the value is null.
Also guard against a user specifying the same directory multiple times by using a HashSet with dictionaries instead of List.

Fixes #90 and #46 