### PR TITLE
Only include newly generated css files in the Content ItemGroup.

### DIFF
--- a/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
+++ b/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <PackageId>AspNetCore.SassCompiler</PackageId>
-    <Version>1.54.4</Version>
+    <Version>1.54.4.1</Version>
     <Authors>koenvzeijl,sleeuwen,Michaelvs97</Authors>
     <Description>Sass Compiler Library for .NET Core 3.1/5.x/6.x. without node</Description>
     <PackageDescription>Sass Compiler Library for .NET Core 3.1/5.x/6.x. without node, using dart-sass as a compiler</PackageDescription>

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -19,7 +19,10 @@
 
     <ItemGroup>
       <None Remove="@(CompiledCssFiles)" />
-      <Content Include="@(CompiledCssFiles)" />
+
+      <!-- Fix to only include files that were newly generated as to not have duplicate Content items. -->
+      <_NewCompiledCssFiles Include="@(CompiledCssFiles)" Exclude="@(Content)" />
+      <Content Include="@(_NewCompiledCssFiles)" />
     </ItemGroup>
   </Target>
 


### PR DESCRIPTION
This fixes an issue where for some applications a build error is thrown when having the same file more than once added to the Content ItemGroup

Fixes #74