### PR TITLE
Feature: watch all projects with the package installed

### DIFF
--- a/AspNetCore.SassCompiler/SassCompilerHostedService.cs
+++ b/AspNetCore.SassCompiler/SassCompilerHostedService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -153,23 +153,28 @@ namespace AspNetCore.SassCompiler
 
         private Process GetSassProcess()
         {
-            var rootFolder = Directory.GetCurrentDirectory();
-
             var command = GetSassCommand();
             if (command.Filename == null)
                 return null;
 
             var directories = new HashSet<string>();
-            directories.Add($"\"{Path.Join(rootFolder, _options.SourceFolder)}\":\"{Path.Join(rootFolder, _options.TargetFolder)}\"");
-            if (_options.GenerateScopedCss)
-            {
-                foreach (var dir in _options.ScopedCssFolders)
-                {
-                    if (dir == _options.SourceFolder)
-                        continue;
+            var sassProjects = Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.sasscompiler");
 
-                    if (Directory.Exists(Path.Join(rootFolder, dir)))
-                        directories.Add($"\"{Path.Join(rootFolder, dir)}\":\"{Path.Join(rootFolder, dir)}\"");
+            foreach (var referenceFile in sassProjects)
+            {
+                var projectFolder = File.ReadAllText(referenceFile).TrimEnd('\r', '\n', '\\');
+                directories.Add($"\"{Path.Join(projectFolder, _options.SourceFolder)}\":\"{Path.Join(projectFolder, _options.TargetFolder)}\"");
+
+                if (_options.GenerateScopedCss)
+                {
+                    foreach (var dir in _options.ScopedCssFolders)
+                    {
+                        if (dir == _options.SourceFolder)
+                            continue;
+
+                        if (Directory.Exists(Path.Join(projectFolder, dir)))
+                            directories.Add($"\"{Path.Join(projectFolder, dir)}\":\"{Path.Join(projectFolder, dir)}\"");
+                    }
                 }
             }
 

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.props
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.props
@@ -55,4 +55,8 @@
     <Content Update="sasscompiler.json" CopyToOutputDirectory="Never" CopyToPublishDirectory="Never" Pack="false" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(SassCompilerEnableWatcher)' != 'false'">
+    <ContentWithTargetPath Include="obj\$(AssemblyName).sasscompiler" TargetPath="$(AssemblyName).sasscompiler" CopyToOutputDirectory="Always" />
+  </ItemGroup>
+
 </Project>

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
 
   <ItemGroup>
     <UpToDateCheckInput Include="**/*.scss" />
@@ -24,6 +24,10 @@
       <_NewCompiledCssFiles Include="@(CompiledCssFiles)" Exclude="@(Content)" />
       <Content Include="@(_NewCompiledCssFiles)" />
     </ItemGroup>
+  </Target>
+
+  <Target Name="Create Sass bin references" BeforeTargets="BeforeBuild">
+    <WriteLinesToFile File="obj\$(AssemblyName).sasscompiler" Lines="$(ProjectDir)" Overwrite="true"/>
   </Target>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ only be an issue when you're developing inside of a docker container, running th
 application in docker is supported as the compiler is automatically run during the MSBuild publish
 step. See [this](https://github.com/koenvzeijl/AspNetCore.SassCompiler/issues/44) issue for the progress.
 
+#### Using Sass watcher in a multi-project setting
+
+If you've styles in multiple projects you will need too install the package into every project that contains styles that need to be compiled.
+
 ## Blazor WASM
 If you use this with Blazor WebAssembly and want to customize the settings you need to use the sasscompiler.json, using appsettings.json is not supported.
 **The sass watcher is currently not supported for Blazor WebAssembly projects**, the MSBuild task is still available and will compile your scss during build and publish.


### PR DESCRIPTION
This PR is solves #57 more elegantly than the solution I presented in the issue. With this solution it's possible to watch multiple projects, or a single referenced project (no need install package into the startup project). The solution should work without breaking current functionality.

I had problems testing this with the sample projects so I couldn't add a new sample. (Tested this locally within another project.)

There are few things that need to be considered such as how configuration will be handled in referenced projects
and other things I probably missed.