### PR TITLE
Make sure to compile SCSS files only once for multi target projects

### DIFF
--- a/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
+++ b/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
@@ -38,6 +38,8 @@
 
   <ItemGroup>
     <None Include="build\*" Pack="true" PackagePath="build" />
+    <None Include="buildMultiTargeting\*" Pack="true" PackagePath="buildMultiTargeting" />
+    <None Include="build\AspNetCore.SassCompiler.targets" Pack="true" PackagePath="buildMultiTargeting" />
     <None Include="runtimes\**" Pack="true" PackagePath="runtimes" />
     <None Include="..\logo.png" Pack="true" PackagePath="\" />
     <None Include="..\README.md" Pack="true" PackagePath="\" />

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
-  
+
   <PropertyGroup Condition="'$(SassCompilerIncludeRuntime)' == 'true'">
     <SassCompilerEnableWatcher>$(SassCompilerIncludeRuntime)</SassCompilerEnableWatcher>
     <SassCompilerRuntimeCopyToPublishDirectory>PreserveNewest</SassCompilerRuntimeCopyToPublishDirectory>

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -1,7 +1,16 @@
-<Project>
+﻿<Project>
 
   <PropertyGroup>
+    <IsOuterBuild Condition="'$(IsOuterBuild)' == ''">false</IsOuterBuild>
+
     <CompileSassBeforeTargets>Build;ResolveScopedCssInputs;BundleMinify;ResolveProjectStaticWebAssets</CompileSassBeforeTargets>
+    <!-- Use DispatchToInnerBuilds if it is a multi-targeted build -->
+    <CompileSassBeforeTargets Condition="$(IsOuterBuild)">DispatchToInnerBuilds</CompileSassBeforeTargets>
+
+    <ShouldRunTarget>false</ShouldRunTarget>
+    <!-- to prevent targets from being run extra times, enforce that only the outer
+         build of a multi-targeted project or a single-targeted build can run -->
+    <ShouldRunTarget Condition="'$(TargetFrameworks)' == '' OR $(IsOuterBuild)">true</ShouldRunTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SassCompilerIncludeRuntime)' == 'true'">
@@ -16,7 +25,7 @@
   <UsingTask TaskName="AspNetCore.SassCompiler.CompileSass"
              AssemblyFile="$(SassCompilerTasksAssembly)" />
 
-  <Target Name="Compile Sass" BeforeTargets="$(CompileSassBeforeTargets)" Condition="'$(DesignTimeBuild)' != 'true'">
+  <Target Name="Compile Sass" BeforeTargets="$(CompileSassBeforeTargets)" Condition="$(ShouldRunTarget) AND '$(DesignTimeBuild)' != 'true'">
     <CompileSass AppsettingsFile="$(SassCompilerAppsettingsJson)"
                  SassCompilerFile="$(SassCompilerSassCompilerJson)"
                  Command="$(SassCompilerBuildCommand)"

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -1,4 +1,8 @@
-﻿<Project>
+<Project>
+
+  <PropertyGroup>
+    <CompileSassBeforeTargets>Build;ResolveScopedCssInputs;BundleMinify;ResolveProjectStaticWebAssets</CompileSassBeforeTargets>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(SassCompilerIncludeRuntime)' == 'true'">
     <SassCompilerEnableWatcher>$(SassCompilerIncludeRuntime)</SassCompilerEnableWatcher>
@@ -12,7 +16,7 @@
   <UsingTask TaskName="AspNetCore.SassCompiler.CompileSass"
              AssemblyFile="$(SassCompilerTasksAssembly)" />
 
-  <Target Name="Compile Sass" BeforeTargets="Build;ResolveScopedCssInputs;BundleMinify;ResolveProjectStaticWebAssets" Condition="'$(DesignTimeBuild)' != 'true'">
+  <Target Name="Compile Sass" BeforeTargets="$(CompileSassBeforeTargets)" Condition="'$(DesignTimeBuild)' != 'true'">
     <CompileSass AppsettingsFile="$(SassCompilerAppsettingsJson)"
                  SassCompilerFile="$(SassCompilerSassCompilerJson)"
                  Command="$(SassCompilerBuildCommand)"

--- a/AspNetCore.SassCompiler/buildMultitargeting/AspNetCore.SassCompiler.props
+++ b/AspNetCore.SassCompiler/buildMultitargeting/AspNetCore.SassCompiler.props
@@ -1,0 +1,11 @@
+﻿<Project>
+
+  <PropertyGroup>
+    <!-- this file only executes in the "outer" build of a multi-targeted project,
+         so we set this variable to keep track of that information -->
+    <IsOuterBuild>true</IsOuterBuild>
+  </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\build\AspNetCore.SassCompiler.props" />
+
+</Project>


### PR DESCRIPTION
This (hopefully) fixes #209.

See https://github.com/koenvzeijl/AspNetCore.SassCompiler/issues/209#issuecomment-2567830100 for more details.