### PR TITLE
Make sure to compile SCSS files only once for multi target projects (attempt #2)

### DIFF
--- a/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
+++ b/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
@@ -38,6 +38,7 @@
 
   <ItemGroup>
     <None Include="build\*" Pack="true" PackagePath="build" />
+    <None Include="build\*" Pack="true" PackagePath="buildMultiTargeting" />
     <None Include="runtimes\**" Pack="true" PackagePath="runtimes" />
     <None Include="..\logo.png" Pack="true" PackagePath="\" />
     <None Include="..\README.md" Pack="true" PackagePath="\" />

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -16,7 +16,9 @@
   <UsingTask TaskName="AspNetCore.SassCompiler.CompileSass"
              AssemblyFile="$(SassCompilerTasksAssembly)" />
 
-  <Target Name="Compile Sass" BeforeTargets="$(CompileSassBeforeTargets)" Condition="'$(DesignTimeBuild)' != 'true'">
+  <Target Name="Compile Sass"
+          BeforeTargets="$(CompileSassBeforeTargets)"
+          Condition="'$(DesignTimeBuild)' != 'true'">
     <CompileSass AppsettingsFile="$(SassCompilerAppsettingsJson)"
                  SassCompilerFile="$(SassCompilerSassCompilerJson)"
                  Command="$(SassCompilerBuildCommand)"

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
-  
+
   <PropertyGroup Condition="'$(SassCompilerIncludeRuntime)' == 'true'">
     <SassCompilerEnableWatcher>$(SassCompilerIncludeRuntime)</SassCompilerEnableWatcher>
     <SassCompilerRuntimeCopyToPublishDirectory>PreserveNewest</SassCompilerRuntimeCopyToPublishDirectory>

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -2,7 +2,15 @@
 
   <PropertyGroup>
     <CompileSassBeforeTargets>Build;ResolveScopedCssInputs;BundleMinify;ResolveProjectStaticWebAssets</CompileSassBeforeTargets>
+    <!-- Use "DispatchToInnerBuilds" if it is a cross-targeting build -->
+    <CompileSassBeforeTargets Condition="'$(IsCrossTargetingBuild)' == 'true'">DispatchToInnerBuilds</CompileSassBeforeTargets>
   </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <_InnerBuildProjects>
+      <Properties>IsCrossTargetedBuild=$(IsCrossTargetingBuild)</Properties>
+    </_InnerBuildProjects>
+  </ItemDefinitionGroup>
 
   <PropertyGroup Condition="'$(SassCompilerIncludeRuntime)' == 'true'">
     <SassCompilerEnableWatcher>$(SassCompilerIncludeRuntime)</SassCompilerEnableWatcher>
@@ -18,7 +26,7 @@
 
   <Target Name="Compile Sass"
           BeforeTargets="$(CompileSassBeforeTargets)"
-          Condition="'$(DesignTimeBuild)' != 'true'">
+          Condition="'$(IsCrossTargetedBuild)' != 'true' AND '$(DesignTimeBuild)' != 'true'">
     <CompileSass AppsettingsFile="$(SassCompilerAppsettingsJson)"
                  SassCompilerFile="$(SassCompilerSassCompilerJson)"
                  Command="$(SassCompilerBuildCommand)"

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -1,4 +1,8 @@
-﻿<Project>
+<Project>
+
+  <PropertyGroup>
+    <CompileSassBeforeTargets>Build;ResolveScopedCssInputs;BundleMinify;ResolveProjectStaticWebAssets</CompileSassBeforeTargets>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(SassCompilerIncludeRuntime)' == 'true'">
     <SassCompilerEnableWatcher>$(SassCompilerIncludeRuntime)</SassCompilerEnableWatcher>
@@ -12,7 +16,7 @@
   <UsingTask TaskName="AspNetCore.SassCompiler.CompileSass"
              AssemblyFile="$(SassCompilerTasksAssembly)" />
 
-  <Target Name="Compile Sass" BeforeTargets="Build;ResolveScopedCssInputs;BundleMinify;ResolveProjectStaticWebAssets" Condition="'$(DesignTimeBuild)' != 'true'">
+  <Target Name="Compile Sass" BeforeTargets="$(CompileSassBeforeTargets)" Condition="'$(DesignTimeBuild)' != 'true'">
     <CompileSass AppsettingsFile="$(SassCompilerAppsettingsJson)"
                  SassCompilerFile="$(SassCompilerSassCompilerJson)"
                  Command="$(SassCompilerBuildCommand)"


### PR DESCRIPTION
This is the second attempt to fix #209 (first attempt is #215).

It seems to work fine at first glance:
+ projects targeting a single framework are handled properly
+ projects targeting multiple frameworks are handled properly
+ even projects targeting multiple frameworks that are build because they are referenced by a project targeting a single framework are handled properly

The problem with the approach of this PR occurs when solution contains a project targeting multiple frameworks that is also being referenced from a project that is targeting a single framework only. In this case the project targeting multiple frameworks gets built twice for the same target framework (as the parameters for building for this target framework are different between being built as referenced project and the inner build) resulting in errors when MSBuild tries to access the same file simultaneously.

Example building `MudBlazor.sln`:

The project `MudBlazor.csproj` gets built three times, twice for `net9.0`:

![image](https://github.com/user-attachments/assets/8dc562d3-d111-4f3a-98a5-0e72d25bc754)

This results in the following failure most of the time:

```
  MudBlazor.Analyzers succeeded (0,2s) → MudBlazor.Analyzers\bin\Release\netstandard2.0\MudBlazor.Analyzers.dll
  MudBlazor.Examples.Data succeeded (0,2s) → MudBlazor.Examples.Data\bin\Release\net9.0\MudBlazor.Examples.Data.dll
  MudBlazor.SourceGenerator succeeded (0,2s) → MudBlazor.SourceGenerator\bin\Release\netstandard2.0\MudBlazor.SourceGenerator.dll
  MudBlazor.Analyzers succeeded (0,1s) → MudBlazor.Analyzers\bin\Release\netstandard2.0\MudBlazor.Analyzers.dll
  MudBlazor.SourceGenerator succeeded (0,1s) → MudBlazor.SourceGenerator\bin\Release\netstandard2.0\MudBlazor.SourceGenerator.dll
  MudBlazor net9.0 failed with 1 error(s) (17,7s)
    CSC : error CS2012: Cannot open 'C:\dev\GitHub\MudBlazor\src\MudBlazor\obj\Release\net9.0\MudBlazor.dll' for writing -- 'The process cannot access the file 'C:\dev\GitHub\MudBlazor\src\MudBlazor\obj\Release\net9.0\MudBlazor.dll' because it is being used by another process.'
  MudBlazor net9.0 succeeded (19,0s) → MudBlazor\bin\Release\net9.0\MudBlazor.dll
  MudBlazor net8.0 succeeded (18,9s) → MudBlazor\bin\Release\net8.0\MudBlazor.dll
  MudBlazor.Docs.Compiler succeeded (1,5s) → MudBlazor.Docs.Compiler\bin\Release\net9.0\MudBlazor.Docs.Compiler.dll
  MudBlazor.UnitTests.Shared succeeded (1,0s) → MudBlazor.UnitTests.Shared\bin\Release\net9.0\MudBlazor.UnitTests.Shared.dll
  MudBlazor.Analyzers.TestComponents succeeded (1,7s) → MudBlazor.Analyzers.TestComponents\bin\Release\net9.0\MudBlazor.Analyzers.TestComponents.dll
  MudBlazor.UnitTests.Viewer succeeded (16,6s) → MudBlazor.UnitTests.Viewer\bin\Release\net9.0\wwwroot
  MudBlazor.UnitTests succeeded (8,9s) → MudBlazor.UnitTests\bin\Release\net9.0\MudBlazor.UnitTests.dll
  MudBlazor.Docs succeeded (49,2s) → MudBlazor.Docs\bin\Release\net9.0\MudBlazor.Docs.dll
  MudBlazor.Docs.Server succeeded (1,3s) → MudBlazor.Docs.Server\bin\Release\net9.0\MudBlazor.Docs.Server.dll
  MudBlazor.UnitTests.Docs succeeded (5,4s) → MudBlazor.UnitTests.Docs\bin\Release\net9.0\MudBlazor.UnitTests.Docs.dll
  MudBlazor.Docs.Wasm succeeded (5,5s) → MudBlazor.Docs.Wasm\bin\Release\net9.0\wwwroot
  MudBlazor.Docs.WasmHost succeeded (2,1s) → MudBlazor.Docs.WasmHost\bin\Release\net9.0\MudBlazor.Docs.WasmHost.dll
```

Occasionally the build succeeds, sometimes it also fails when accessing other files:

```
  MudBlazor.SourceGenerator succeeded (0,3s) → MudBlazor.SourceGenerator\bin\Release\netstandard2.0\MudBlazor.SourceGenerator.dll
  MudBlazor.Examples.Data succeeded (0,3s) → MudBlazor.Examples.Data\bin\Release\net9.0\MudBlazor.Examples.Data.dll
  MudBlazor.Analyzers succeeded (0,3s) → MudBlazor.Analyzers\bin\Release\netstandard2.0\MudBlazor.Analyzers.dll
  MudBlazor.Analyzers succeeded (0,1s) → MudBlazor.Analyzers\bin\Release\netstandard2.0\MudBlazor.Analyzers.dll
  MudBlazor.SourceGenerator succeeded (0,1s) → MudBlazor.SourceGenerator\bin\Release\netstandard2.0\MudBlazor.SourceGenerator.dll
  MudBlazor net9.0 failed with 1 error(s) (0,3s)
    C:\Program Files\dotnet\sdk\9.0.101\Roslyn\Microsoft.Managed.Core.targets(191,5): error : The process cannot access the file 'C:\dev\GitHub\MudBlazor\src\MudBlazor\obj\Release\net9.0\MudBlazor.GeneratedMSBuildEditorConfig.editorconfig' because it is being used by another process.
  MudBlazor net8.0 succeeded (14,7s) → MudBlazor\bin\Release\net8.0\MudBlazor.dll
  MudBlazor net9.0 succeeded (14,7s) → MudBlazor\bin\Release\net9.0\MudBlazor.dll
  MudBlazor.UnitTests.Shared succeeded (2,4s) → MudBlazor.UnitTests.Shared\bin\Release\net9.0\MudBlazor.UnitTests.Shared.dll
  MudBlazor.Docs.Compiler succeeded (2,8s) → MudBlazor.Docs.Compiler\bin\Release\net9.0\MudBlazor.Docs.Compiler.dll
  MudBlazor.Analyzers.TestComponents succeeded (3,6s) → MudBlazor.Analyzers.TestComponents\bin\Release\net9.0\MudBlazor.Analyzers.TestComponents.dll
  MudBlazor.UnitTests.Viewer succeeded (16,7s) → MudBlazor.UnitTests.Viewer\bin\Release\net9.0\wwwroot
  MudBlazor.UnitTests succeeded (11,3s) → MudBlazor.UnitTests\bin\Release\net9.0\MudBlazor.UnitTests.dll
  MudBlazor.Docs succeeded (49,8s) → MudBlazor.Docs\bin\Release\net9.0\MudBlazor.Docs.dll
  MudBlazor.Docs.Server succeeded (2,2s) → MudBlazor.Docs.Server\bin\Release\net9.0\MudBlazor.Docs.Server.dll
  MudBlazor.UnitTests.Docs succeeded (7,1s) → MudBlazor.UnitTests.Docs\bin\Release\net9.0\MudBlazor.UnitTests.Docs.dll
  MudBlazor.Docs.Wasm succeeded (7,6s) → MudBlazor.Docs.Wasm\bin\Release\net9.0\wwwroot
  MudBlazor.Docs.WasmHost succeeded (2,0s) → MudBlazor.Docs.WasmHost\bin\Release\net9.0\MudBlazor.Docs.WasmHost.dll
```

All in all this is not a solution. I just wanted to put it here for documentation purposes.