### PR TITLE
Use Mutex to prevent simultaneous SCSS compilation for multi target projects

### DIFF
--- a/AspNetCore.SassCompiler.Tasks/CompileSass.cs
+++ b/AspNetCore.SassCompiler.Tasks/CompileSass.cs
@@ -286,7 +286,7 @@ namespace AspNetCore.SassCompiler
             var mutexName = GetMutexName();
 
             Log.LogMessage(MessageImportance.Normal,
-                $"TargetFrameworks: '{TargetFrameworks}'; using mutex {mutexName}");
+                $"TargetFramework: '{TargetFramework}'; TargetFrameworks: '{TargetFrameworks}'; using mutex {mutexName}");
 
             using var mutex = new Mutex(false, mutexName);
 

--- a/AspNetCore.SassCompiler.Tasks/CompileSass.cs
+++ b/AspNetCore.SassCompiler.Tasks/CompileSass.cs
@@ -294,11 +294,11 @@ namespace AspNetCore.SassCompiler
             {
                 error += e.Data + Environment.NewLine;
             };
-            
+
             compiler.Start();
 
             compiler.BeginErrorReadLine();
-            
+
             var output = compiler.StandardOutput.ReadToEnd();
 
             compiler.WaitForExit();

--- a/AspNetCore.SassCompiler.Tasks/CompileSass.cs
+++ b/AspNetCore.SassCompiler.Tasks/CompileSass.cs
@@ -30,6 +30,10 @@ namespace AspNetCore.SassCompiler
 
         public string Configuration { get; set; }
 
+        public string TargetFramework { get; set; }
+
+        public string TargetFrameworks { get; set; }
+
         [Output]
         public ITaskItem[] GeneratedFiles { get; set; } = Array.Empty<ITaskItem>();
 

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -1,4 +1,4 @@
-﻿<Project>
+<Project>
 
   <PropertyGroup Condition="'$(SassCompilerIncludeRuntime)' == 'true'">
     <SassCompilerEnableWatcher>$(SassCompilerIncludeRuntime)</SassCompilerEnableWatcher>
@@ -19,7 +19,9 @@
                  SassCompilerFile="$(SassCompilerSassCompilerJson)"
                  Command="$(SassCompilerBuildCommand)"
                  Snapshot="$(SassCompilerBuildSnapshot)"
-                 Configuration="$(SassCompilerConfiguration)">
+                 Configuration="$(SassCompilerConfiguration)"
+                 TargetFramework="$(TargetFramework)"
+                 TargetFrameworks="$(TargetFrameworks)">
       <Output TaskParameter="GeneratedFiles"
               ItemName="CompiledCssFiles" />
     </CompileSass>

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -1,5 +1,5 @@
 ﻿<Project>
-  
+
   <PropertyGroup Condition="'$(SassCompilerIncludeRuntime)' == 'true'">
     <SassCompilerEnableWatcher>$(SassCompilerIncludeRuntime)</SassCompilerEnableWatcher>
     <SassCompilerRuntimeCopyToPublishDirectory>PreserveNewest</SassCompilerRuntimeCopyToPublishDirectory>

--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.targets
@@ -12,7 +12,9 @@
   <UsingTask TaskName="AspNetCore.SassCompiler.CompileSass"
              AssemblyFile="$(SassCompilerTasksAssembly)" />
 
-  <Target Name="Compile Sass" BeforeTargets="Build;ResolveScopedCssInputs;BundleMinify;ResolveProjectStaticWebAssets" Condition="'$(DesignTimeBuild)' != 'true'">
+  <Target Name="Compile Sass"
+          BeforeTargets="Build;ResolveScopedCssInputs;BundleMinify;ResolveProjectStaticWebAssets"
+          Condition="'$(DesignTimeBuild)' != 'true'">
     <CompileSass AppsettingsFile="$(SassCompilerAppsettingsJson)"
                  SassCompilerFile="$(SassCompilerSassCompilerJson)"
                  Command="$(SassCompilerBuildCommand)"


### PR DESCRIPTION
This is the third (and final) attempt to fix #209 (first attempt is #215, second is #217).

The other attempts have unfortunately shown that there are various problems when trying to compile SCSS files only once for multi target projects. Using a Mutex as @mikes-gh suggested to prevent simultaneous compilation for such projects seems to be the only viable option.

This PR wraps the SCSS compilation for projects targeting multiple frameworks with a Mutex to prevent simultaneous execution, in all other cases the compilation happens directly (without Mutex) like before.

Including the hashed arguments in the Mutex name makes sure the compilation for different projects (using different arguments) can still happen simultaneously.