### PR TITLE
Fix deadlocking when reading StandardOutput and StandardError in SassCompiler.cs

### DIFF
--- a/AspNetCore.SassCompiler/SassCompiler.cs
+++ b/AspNetCore.SassCompiler/SassCompiler.cs
@@ -43,8 +43,8 @@ internal class SassCompiler : ISassCompiler
 
         process.Start();
         ChildProcessTracker.AddProcess(process);
-        Task outputTask = process.StandardOutput.BaseStream.CopyToAsync(Stream.Null);
-        Task errorTask = process.StandardError.BaseStream.CopyToAsync(errorOutput);
+        var outputTask = process.StandardOutput.BaseStream.CopyToAsync(Stream.Null);
+        var errorTask = process.StandardError.BaseStream.CopyToAsync(errorOutput);
         await Task.WhenAll(outputTask, errorTask, process.WaitForExitAsync());
 
         if (process.ExitCode != 0)
@@ -83,8 +83,8 @@ internal class SassCompiler : ISassCompiler
         ChildProcessTracker.AddProcess(process);
         await input.CopyToAsync(process.StandardInput.BaseStream);
         await process.StandardInput.DisposeAsync();
-        Task outputTask = process.StandardOutput.BaseStream.CopyToAsync(output);
-        Task errorTask = process.StandardError.BaseStream.CopyToAsync(errorOutput);
+        var outputTask = process.StandardOutput.BaseStream.CopyToAsync(output);
+        var errorTask = process.StandardError.BaseStream.CopyToAsync(errorOutput);
         await Task.WhenAll(outputTask, errorTask, process.WaitForExitAsync());
 
         if (process.ExitCode != 0)

--- a/AspNetCore.SassCompiler/SassCompiler.cs
+++ b/AspNetCore.SassCompiler/SassCompiler.cs
@@ -43,9 +43,9 @@ internal class SassCompiler : ISassCompiler
 
         process.Start();
         ChildProcessTracker.AddProcess(process);
-        await process.StandardOutput.BaseStream.CopyToAsync(Stream.Null);
-        await process.StandardError.BaseStream.CopyToAsync(errorOutput);
-        await process.WaitForExitAsync();
+        Task outputTask = process.StandardOutput.BaseStream.CopyToAsync(Stream.Null);
+        Task errorTask = process.StandardError.BaseStream.CopyToAsync(errorOutput);
+        await Task.WhenAll(outputTask, errorTask, process.WaitForExitAsync());
 
         if (process.ExitCode != 0)
         {
@@ -83,9 +83,9 @@ internal class SassCompiler : ISassCompiler
         ChildProcessTracker.AddProcess(process);
         await input.CopyToAsync(process.StandardInput.BaseStream);
         await process.StandardInput.DisposeAsync();
-        await process.StandardOutput.BaseStream.CopyToAsync(output);
-        await process.StandardError.BaseStream.CopyToAsync(errorOutput);
-        await process.WaitForExitAsync();
+        Task outputTask = process.StandardOutput.BaseStream.CopyToAsync(output);
+        Task errorTask = process.StandardError.BaseStream.CopyToAsync(errorOutput);
+        await Task.WhenAll(outputTask, errorTask, process.WaitForExitAsync());
 
         if (process.ExitCode != 0)
         {


### PR DESCRIPTION
This is a fix for the bug I reported [here](https://github.com/koenvzeijl/AspNetCore.SassCompiler/issues/220)

When processing input that generates enough output to StandardError to fill the buffer, the current implementation of SassCompiler is awaiting reading from StandardOutput whilst the child process is waiting for its now full StandardError buffer to be read from in order to continue processing. This change sees StandardOutput and StandardError being read from asynchronously at the same time which prevents the buffers from filling up and causing a deadlock.

You can run the new tests against the previous implementation of `SassCompiler.cs` to reproduce the issue.