### PR TITLE
chore: Mark Includes in `AspNetCore.SassCompiler.props` as `Visible="false"`

### DIFF
--- a/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.props
+++ b/AspNetCore.SassCompiler/build/AspNetCore.SassCompiler.props
@@ -43,16 +43,16 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(SassCompilerEnableWatcher)' != 'false'">
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\src\dart.exe" Link="runtimes\win-x64\src\dart.exe" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\src\sass.snapshot" Link="runtimes\win-x64\src\sass.snapshot" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\src\dart" Link="runtimes\linux-x64\src\dart" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\src\sass.snapshot" Link="runtimes\linux-x64\src\sass.snapshot" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\linux-arm64\src\dart" Link="runtimes\linux-arm64\src\dart" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\linux-arm64\src\sass.snapshot" Link="runtimes\linux-arm64\src\sass.snapshot" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\osx-x64\src\dart" Link="runtimes\osx-x64\src\dart" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\osx-x64\src\sass.snapshot" Link="runtimes\osx-x64\src\sass.snapshot" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\osx-arm64\src\dart" Link="runtimes\osx-arm64\src\dart" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" />
-    <None Include="$(MSBuildThisFileDirectory)..\runtimes\osx-arm64\src\sass.snapshot" Link="runtimes\osx-arm64\src\sass.snapshot" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" />
+    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\src\dart.exe" Link="runtimes\win-x64\src\dart.exe" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\runtimes\win-x64\src\sass.snapshot" Link="runtimes\win-x64\src\sass.snapshot" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\src\dart" Link="runtimes\linux-x64\src\dart" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\runtimes\linux-x64\src\sass.snapshot" Link="runtimes\linux-x64\src\sass.snapshot" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\runtimes\linux-arm64\src\dart" Link="runtimes\linux-arm64\src\dart" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\runtimes\linux-arm64\src\sass.snapshot" Link="runtimes\linux-arm64\src\sass.snapshot" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\runtimes\osx-x64\src\dart" Link="runtimes\osx-x64\src\dart" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\runtimes\osx-x64\src\sass.snapshot" Link="runtimes\osx-x64\src\sass.snapshot" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\runtimes\osx-arm64\src\dart" Link="runtimes\osx-arm64\src\dart" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" Visible="false" />
+    <None Include="$(MSBuildThisFileDirectory)..\runtimes\osx-arm64\src\sass.snapshot" Link="runtimes\osx-arm64\src\sass.snapshot" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="$(SassCompilerRuntimeCopyToPublishDirectory)" Visible="false" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(SassCompilerEnableWatcher)' == 'false'">


### PR DESCRIPTION
This pull request updates the `<None Include... />` element in the `AspNetCore.SassCompiler.props` file by marking it with the attribute `Visible="false"`. 

### Purpose

The change is intended to:
1. Prevent the specified files from appearing in the solution explorer in IDEs like Visual Studio.
2. Enhance the developer experience by reducing clutter and avoiding confusion caused by displaying files that are not directly intended for modification.

### Impact

This modification is purely a visual improvement and does not affect the build process, functionality, or behavior of the Sass compiler or the project.

### Testing

- Verified that the files are no longer displayed in the solution explorer in Visual Studio.
- Confirmed that the build process remains unaffected by this change. 