### PR TITLE
Fix path for Arm64 architecture in SassCompiler

### DIFF
--- a/AspNetCore.SassCompiler/SassCompiler.cs
+++ b/AspNetCore.SassCompiler/SassCompiler.cs
@@ -192,7 +192,7 @@ internal class SassCompiler : ISassCompiler
             return RuntimeInformation.OSArchitecture switch
             {
                 Architecture.X64 => ("runtimes/linux-x64/src/dart", "runtimes/linux-x64/src/sass.snapshot"),
-                Architecture.Arm64 => ("runtimes/linux-arm64/src/dart", "runtimes/linux-x64/src/sass.snapshot"),
+                Architecture.Arm64 => ("runtimes/linux-arm64/src/dart", "runtimes/linux-arm64/src/sass.snapshot"),
                 _ => (null, null),
             };
         }


### PR DESCRIPTION
This PR fixes the path to the linux arm64 sass.snapshot file. It was incorrectly set to `runtimes/linux-x64/src/sass.snapshot` instead of `runtimes/linux-arm64/src/sass.snapshot`