### PR TITLE
Fix Windows long-path Sass compilation

### DIFF
--- a/AspNetCore.SassCompiler.Tasks/AspNetCore.SassCompiler.Tasks.csproj
+++ b/AspNetCore.SassCompiler.Tasks/AspNetCore.SassCompiler.Tasks.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Include="..\AspNetCore.SassCompiler\SassCliPathHelper.cs" />
     <Compile Include="..\AspNetCore.SassCompiler\SassCompilerOptions.cs" />
     <Compile Include="..\AspNetCore.SassCompiler\SassCompilerCompilationOptions.cs" />
   </ItemGroup>

--- a/AspNetCore.SassCompiler.Tasks/CompileSass.cs
+++ b/AspNetCore.SassCompiler.Tasks/CompileSass.cs
@@ -214,6 +214,12 @@ namespace AspNetCore.SassCompiler
         private IEnumerable<ITaskItem> GenerateCss(SassCompilerOptions options)
         {
             var rootFolder = Directory.GetCurrentDirectory();
+            var compilations = options.GetAllCompilations().ToArray();
+            using var pathContext = SassCliPathHelper.CreateContext(
+                rootFolder,
+                compilations.SelectMany(compilation => new[] { compilation.Source, compilation.Target })
+                    .Concat(options.IncludePaths ?? Array.Empty<string>())
+                    .ToArray());
 
             var processArguments = new StringBuilder();
             processArguments.Append(Snapshot);
@@ -223,15 +229,15 @@ namespace AspNetCore.SassCompiler
             {
                 foreach (var includePath in options.IncludePaths)
                 {
-                    processArguments.AppendFormat(" --load-path={0}", includePath);
+                    processArguments.Append(pathContext.CreateLoadPathArgument(includePath));
                 }
             }
 
             var hasSources = false;
-            foreach (var compilation in options.GetAllCompilations())
+            foreach (var compilation in compilations)
             {
-                var fullSource = Path.GetFullPath(Path.Combine(rootFolder, compilation.Source));
-                var fullTarget = Path.GetFullPath(Path.Combine(rootFolder, compilation.Target));
+                var fullSource = pathContext.GetFullPath(compilation.Source);
+                var fullTarget = pathContext.GetFullPath(compilation.Target);
 
                 if (!Directory.Exists(fullSource) && !File.Exists(fullSource))
                 {
@@ -242,7 +248,7 @@ namespace AspNetCore.SassCompiler
                 }
 
                 hasSources = true;
-                processArguments.AppendFormat(" \"{0}\":\"{1}\"", fullSource, fullTarget);
+                processArguments.Append(pathContext.CreateUpdateMappingArgument(compilation.Source, compilation.Target));
             }
 
             if (!hasSources)
@@ -252,7 +258,7 @@ namespace AspNetCore.SassCompiler
 
             var arguments = processArguments.ToString();
 
-            var (success, output, error) = GenerateCss(arguments);
+            var (success, output, error) = GenerateCss(pathContext.WorkingDirectory, arguments);
 
             if (!success)
             {
@@ -276,11 +282,11 @@ namespace AspNetCore.SassCompiler
             }
         }
 
-        private (bool Success, string Output, string Error) GenerateCss(string arguments)
+        private (bool Success, string Output, string Error) GenerateCss(string workingDirectory, string arguments)
         {
             if (string.IsNullOrWhiteSpace(TargetFrameworks))
             {
-                return CompileCss(arguments);
+                return CompileCss(workingDirectory, arguments);
             }
 
             var mutexName = GetMutexName();
@@ -301,7 +307,7 @@ namespace AspNetCore.SassCompiler
 
             try
             {
-                return CompileCss(arguments);
+                return CompileCss(workingDirectory, arguments);
             }
             finally
             {
@@ -319,13 +325,14 @@ namespace AspNetCore.SassCompiler
             }
         }
 
-        private (bool Success, string Output, string Error) CompileCss(string arguments)
+        private (bool Success, string Output, string Error) CompileCss(string workingDirectory, string arguments)
         {
             var compiler = new Process();
             compiler.StartInfo = new ProcessStartInfo
             {
                 FileName = Command,
                 Arguments = arguments,
+                WorkingDirectory = workingDirectory,
                 UseShellExecute = false,
                 CreateNoWindow = true,
                 RedirectStandardOutput = true,

--- a/AspNetCore.SassCompiler.Tests/AspNetCore.SassCompiler.Tests.csproj
+++ b/AspNetCore.SassCompiler.Tests/AspNetCore.SassCompiler.Tests.csproj
@@ -21,6 +21,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="16.4.0" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.4.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="xunit" Version="2.8.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
@@ -35,6 +37,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AspNetCore.SassCompiler\AspNetCore.SassCompiler.csproj" />
+    <ProjectReference Include="..\AspNetCore.SassCompiler.Tasks\AspNetCore.SassCompiler.Tasks.csproj" />
   </ItemGroup>
 
   <!-- Only needed because we're using a ProjectReference, this is done implicitly for PackageReference's -->

--- a/AspNetCore.SassCompiler.Tests/CompileSassWindowsLongPathTests.cs
+++ b/AspNetCore.SassCompiler.Tests/CompileSassWindowsLongPathTests.cs
@@ -1,0 +1,171 @@
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using AspNetCore.SassCompiler;
+using Microsoft.Build.Framework;
+using Xunit;
+
+namespace AspNetCore.SassCompiler.Tests;
+
+public class CompileSassWindowsLongPathTests
+{
+    private static readonly object _currentDirectoryLock = new();
+
+    [Fact]
+    public void CreateContext_OnWindowsWithLongResolvedPaths_UsesShortWorkingDirectory()
+    {
+        // Arrange
+        var rootDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var longRelativePath = Path.Combine(
+            "obj",
+            "Debug",
+            "net9.0",
+            "scopedcss",
+            new string('x', 50),
+            new string('y', 50),
+            new string('z', 50));
+        Directory.CreateDirectory(Path.Combine(rootDirectory, "Styles"));
+
+        try
+        {
+            // Act
+            using var context = SassCliPathHelper.CreateContext(rootDirectory, longRelativePath);
+
+            // Assert
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.NotEqual(rootDirectory, context.WorkingDirectory);
+                Assert.True(Directory.Exists(context.WorkingDirectory));
+                Assert.Equal("Styles/site.scss", context.CreateUpdateMappingArgument("Styles/site.scss", "wwwroot/css/site.css").Split('"')[1]);
+            }
+            else
+            {
+                Assert.Equal(rootDirectory, context.WorkingDirectory);
+            }
+        }
+        finally
+        {
+            DeleteDirectoryQuietly(rootDirectory);
+        }
+    }
+
+    [Fact]
+    public void Execute_OnWindows_CompilesDeepDirectoryMappingsWithoutSassDirectoryListing()
+    {
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var rootDirectory = CreateLongRootDirectory();
+        var sourceDirectory = Path.Combine(rootDirectory, "Styles");
+        var sourceRelative = Path.Combine("Components", "Feature", "VariantForms", "SubArea", "DeepArea");
+        var targetFile = Path.Combine(rootDirectory, "obj", "Debug", "net9.0", "scopedcss", "Components", "Feature", "VariantForms", "SubArea", "DeepArea", "site.css");
+        var configFile = Path.Combine(rootDirectory, "sasscompiler.json");
+
+        Directory.CreateDirectory(Path.Combine(sourceDirectory, sourceRelative));
+        File.WriteAllText(Path.Combine(sourceDirectory, sourceRelative, "site.scss"), "body { color: black; }");
+        File.WriteAllText(configFile,
+            "{\n" +
+            "  \"Source\": \"Styles/Components\",\n" +
+            "  \"Target\": \"obj/Debug/net9.0/scopedcss/Components\",\n" +
+            "  \"Arguments\": \"--no-source-map\"\n" +
+            "}");
+
+        var sassCommand = SassCompiler.GetSassCommand();
+        var task = new CompileSass
+        {
+            AppsettingsFile = Path.Combine(rootDirectory, "appsettings.json"),
+            SassCompilerFile = configFile,
+            Command = sassCommand.Filename,
+            Snapshot = sassCommand.Snapshot.Trim('"'),
+            Configuration = "Debug",
+            BuildEngine = new TestBuildEngine()
+        };
+
+        var originalDirectory = Directory.GetCurrentDirectory();
+
+        try
+        {
+            lock (_currentDirectoryLock)
+            {
+                Directory.SetCurrentDirectory(rootDirectory);
+
+                // Act
+                var succeeded = task.Execute();
+
+                // Assert
+                Assert.True(succeeded);
+                Assert.True(File.Exists(targetFile));
+                Assert.Equal("body {\n  color: black;\n}\n", File.ReadAllText(targetFile));
+            }
+        }
+        finally
+        {
+            lock (_currentDirectoryLock)
+            {
+                Directory.SetCurrentDirectory(originalDirectory);
+            }
+
+            DeleteDirectoryQuietly(rootDirectory);
+        }
+    }
+
+    private static string CreateLongRootDirectory()
+    {
+        var baseDirectory = Path.Combine(Path.GetTempPath(), "aspnetcore-sasscompiler-tests", new string('x', 110));
+        var rootDirectory = Path.Combine(baseDirectory, new string('y', 40), Path.GetRandomFileName());
+        Directory.CreateDirectory(rootDirectory);
+        return rootDirectory;
+    }
+
+    private static void DeleteDirectoryQuietly(string path)
+    {
+        for (var attempt = 0; attempt < 5; attempt++)
+        {
+            try
+            {
+                if (Directory.Exists(path))
+                    Directory.Delete(path, true);
+
+                return;
+            }
+            catch (IOException) when (attempt < 4)
+            {
+                Thread.Sleep(100);
+            }
+            catch (UnauthorizedAccessException) when (attempt < 4)
+            {
+                Thread.Sleep(100);
+            }
+        }
+    }
+
+    private sealed class TestBuildEngine : IBuildEngine
+    {
+        public bool ContinueOnError => false;
+
+        public int LineNumberOfTaskNode => 0;
+
+        public int ColumnNumberOfTaskNode => 0;
+
+        public string ProjectFileOfTaskNode => string.Empty;
+
+        public void LogErrorEvent(BuildErrorEventArgs e)
+        {
+        }
+
+        public void LogWarningEvent(BuildWarningEventArgs e)
+        {
+        }
+
+        public void LogMessageEvent(BuildMessageEventArgs e)
+        {
+        }
+
+        public void LogCustomEvent(CustomBuildEventArgs e)
+        {
+        }
+
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, System.Collections.IDictionary globalProperties, System.Collections.IDictionary targetOutputs)
+            => true;
+    }
+}

--- a/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
+++ b/AspNetCore.SassCompiler/AspNetCore.SassCompiler.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <PackageId>AspNetCore.SassCompiler</PackageId>
-    <Version>1.101.0</Version>
+    <Version>1.101.3</Version>
     <Authors>koenvzeijl,sleeuwen,Michaelvs97</Authors>
     <Description>Sass Compiler Library for .NET 6 and above. without node</Description>
     <PackageDescription>Sass Compiler Library for .NET 6 and above. without node, using dart-sass as a compiler</PackageDescription>

--- a/AspNetCore.SassCompiler/SassCliPathHelper.cs
+++ b/AspNetCore.SassCompiler/SassCliPathHelper.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+
+namespace AspNetCore.SassCompiler;
+
+internal static class SassCliPathHelper
+{
+    internal static SassCliPathContext CreateContext(string rootFolder, params string[] candidatePaths)
+        => SassCliPathContext.Create(rootFolder, candidatePaths);
+
+    internal sealed class SassCliPathContext : IDisposable
+    {
+        private readonly string _rootFolder;
+        private readonly string _shortWorkingDirectory;
+
+        private SassCliPathContext(string rootFolder, string shortWorkingDirectory)
+        {
+            _rootFolder = rootFolder;
+            _shortWorkingDirectory = shortWorkingDirectory;
+        }
+
+        internal string WorkingDirectory => _shortWorkingDirectory ?? _rootFolder;
+
+        internal static SassCliPathContext Create(string rootFolder, string[] candidatePaths)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                || rootFolder.StartsWith(@"\\", StringComparison.Ordinal))
+            {
+                return new SassCliPathContext(rootFolder, null);
+            }
+
+            var driveRoot = Path.GetPathRoot(rootFolder);
+            if (string.IsNullOrWhiteSpace(driveRoot))
+                return new SassCliPathContext(rootFolder, null);
+
+            var linkPath = Path.Combine(driveRoot, $"asc-{Guid.NewGuid():N}".Substring(0, 12));
+
+            try
+            {
+                var process = new Process
+                {
+                    StartInfo = new ProcessStartInfo
+                    {
+                        FileName = Environment.GetEnvironmentVariable("ComSpec") ?? "cmd.exe",
+                        Arguments = $"/c mklink /J \"{linkPath}\" \"{rootFolder}\"",
+                        UseShellExecute = false,
+                        CreateNoWindow = true,
+                        RedirectStandardOutput = true,
+                        RedirectStandardError = true
+                    }
+                };
+
+                process.Start();
+                process.WaitForExit();
+                process.Dispose();
+
+                if (Directory.Exists(linkPath))
+                    return new SassCliPathContext(rootFolder, linkPath);
+            }
+            catch
+            {
+                // Fall back to the original working directory when a short alias cannot be created.
+            }
+
+            return new SassCliPathContext(rootFolder, null);
+        }
+
+        internal string GetFullPath(string path)
+            => Path.GetFullPath(Path.Combine(_rootFolder, path));
+
+        internal string CreateLoadPathArgument(string path)
+            => $" --load-path=\"{GetProcessPath(path)}\"";
+
+        internal string CreateUpdateMappingArgument(string source, string target)
+            => $" \"{GetProcessPath(source)}\":\"{GetProcessPath(target)}\"";
+
+        private string GetProcessPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return path;
+
+            var fullPath = Path.GetFullPath(Path.Combine(_rootFolder, path));
+
+            if (_shortWorkingDirectory is null || Path.IsPathRooted(path) is false)
+                return NormalizeSeparators(path);
+
+            if (!IsUnderRoot(fullPath))
+                return fullPath;
+
+            return NormalizeSeparators(GetRelativePath(_rootFolder, fullPath));
+        }
+
+        private bool IsUnderRoot(string fullPath)
+        {
+            var rootWithSeparator = AppendDirectorySeparator(_rootFolder);
+            return fullPath.StartsWith(rootWithSeparator, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(fullPath, _rootFolder, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public void Dispose()
+        {
+            if (_shortWorkingDirectory is null)
+                return;
+
+            try
+            {
+                if (Directory.Exists(_shortWorkingDirectory))
+                    Directory.Delete(_shortWorkingDirectory);
+            }
+            catch
+            {
+                // The junction is best-effort cleanup only.
+            }
+        }
+    }
+
+    private static string GetRelativePath(string folder, string path)
+    {
+        var folderUri = new Uri(AppendDirectorySeparator(folder));
+        var pathUri = new Uri(path);
+        var relativeUri = folderUri.MakeRelativeUri(pathUri);
+        return Uri.UnescapeDataString(relativeUri.ToString()).Replace('/', Path.DirectorySeparatorChar);
+    }
+
+    private static string AppendDirectorySeparator(string path)
+        => path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+            ? path
+            : path + Path.DirectorySeparatorChar;
+
+    private static string NormalizeSeparators(string path)
+        => path.Replace('\\', '/');
+}

--- a/AspNetCore.SassCompiler/SassCompilerHostedService.cs
+++ b/AspNetCore.SassCompiler/SassCompilerHostedService.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Text;
 using System.Text.Json;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
@@ -17,6 +18,7 @@ namespace AspNetCore.SassCompiler
         private readonly SassCompilerOptions _options;
 
         private Process _process;
+        private IDisposable _pathContext;
         private bool _isStopping = false;
 
         public SassCompilerHostedService(IConfiguration configuration, ILogger<SassCompilerHostedService> logger)
@@ -83,6 +85,9 @@ namespace AspNetCore.SassCompiler
                 _process = null;
             }
 
+            _pathContext?.Dispose();
+            _pathContext = null;
+
             return Task.CompletedTask;
         }
 
@@ -99,6 +104,9 @@ namespace AspNetCore.SassCompiler
                 _process.Dispose();
                 _process = null;
             }
+
+            _pathContext?.Dispose();
+            _pathContext = null;
         }
 
         private void StartProcess()
@@ -151,6 +159,14 @@ namespace AspNetCore.SassCompiler
         private Process GetSassProcess()
         {
             var rootFolder = Directory.GetCurrentDirectory();
+            var compilations = _options.GetAllCompilations().ToArray();
+            _pathContext?.Dispose();
+            var pathContext = SassCliPathHelper.CreateContext(
+                rootFolder,
+                compilations.SelectMany(compilation => new[] { compilation.Source, compilation.Target })
+                    .Concat(_options.IncludePaths ?? Array.Empty<string>())
+                    .ToArray());
+            _pathContext = pathContext;
 
             var processArguments = new StringBuilder();
             processArguments.Append(" --error-css");
@@ -161,22 +177,23 @@ namespace AspNetCore.SassCompiler
             {
                 foreach (var includePath in _options.IncludePaths)
                 {
-                    processArguments.Append($" --load-path={includePath}");
+                    processArguments.Append(pathContext.CreateLoadPathArgument(includePath));
                 }
             }
 
-            foreach (var compilation in _options.GetAllCompilations())
+            foreach (var compilation in compilations)
             {
-                var fullSource = Path.GetFullPath(Path.Combine(rootFolder, compilation.Source));
-                var fullTarget = Path.GetFullPath(Path.Combine(rootFolder, compilation.Target));
+                var fullSource = pathContext.GetFullPath(compilation.Source);
+                var fullTarget = pathContext.GetFullPath(compilation.Target);
 
                 if (!Directory.Exists(fullSource) && !File.Exists(fullSource))
                     continue;
 
-                processArguments.Append($" \"{fullSource}\":\"{fullTarget}\"");
+                processArguments.Append(pathContext.CreateUpdateMappingArgument(compilation.Source, compilation.Target));
             }
 
             var process = SassCompiler.CreateSassProcess(processArguments.ToString());
+            process.StartInfo.WorkingDirectory = pathContext.WorkingDirectory;
             return process;
         }
     }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ dotnet add package AspNetCore.SassCompiler
 After adding the package, the Sass styles from the Source (defaults to: Styles) will automatically be compiled into `.css` files in the TargetFolder (defaults to: wwwroot\css) on build. 
 You can also adjust the default configuration in the appsettings.json or sasscompiler.json, do note that when using `appsettings.json` the configuration needs to be nested under a "SassCompiler" property, but when you're using `sasscompiler.json` the settings should _not_ be nested.
 
+On Windows, the package runs dart-sass from a short temporary working path for local builds. This avoids dart-sass directory-listing failures and Windows process-start failures for deep scoped CSS paths, while keeping the normal directory-watch behavior intact.
+
 ### Available options
 
 | Name              | Default value                              | Description                                                                                                                                       |


### PR DESCRIPTION
## Root cause
On Windows, deep Blazor scopedcss paths in FlexyBox (for example `obj\Debug\net9.0\scopedcss\Presentation\...\*`) can trigger dart-sass directory-listing failures. Earlier mitigation by expanding to per-file mappings can also exceed Windows process argument limits.

## What changed
- Added `SassCliPathHelper` to create a short temporary local alias path on Windows.
- Updated both MSBuild task (`CompileSass`) and hosted watcher (`SassCompilerHostedService`) to run sass through that short-path context on Windows local builds.
- Kept non-Windows behavior unchanged.
- Added Windows regression tests for deep scopedcss-style mappings.
- Bumped package version to `1.101.3`.

## Why this fixes it
Sass no longer operates from very long local filesystem roots on Windows, so both path-enumeration failures and command-line-length pressure are avoided while preserving existing source/target mapping behavior.